### PR TITLE
Fix import and env loading duplication

### DIFF
--- a/etl/facebook/media_extract.py
+++ b/etl/facebook/media_extract.py
@@ -1,16 +1,11 @@
 import requests
 import os
 import sys
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../../')))
 from dotenv import load_dotenv
-from etl.utils.helpers import obtener_tokens_paginas
-from etl.utils.lookup import get_sql_connection
-from etl.utils.helpers import obtener_ids_publicaciones
+from etl.utils.helpers import obtener_tokens_paginas, obtener_ids_publicaciones
 
-dotenv_path = os.path.join(os.path.dirname(__file__), '../../config/.env')
-load_dotenv(dotenv_path)
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../../')))
 
-# Cargar las variables del archivo .env
 dotenv_path = os.path.join(os.path.dirname(__file__), '../../config/.env')
 load_dotenv(dotenv_path)
 FB_TOKEN  = os.getenv("FB_TOKEN")


### PR DESCRIPTION
## Summary
- clean up media_extract module
- remove unused import and duplicate load_dotenv call

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845a34d19c08330bd774c78152335dc